### PR TITLE
fix: :bug: readme screenshot + typo sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The segmentation postprocessing is performed with OpenCV.js
 
 This is what it looks like when you launch the app:
 
-![demo](https://github.com/teamMindee/tensorflow-js-demo/releases/download/v0.1-models/demo.png)
+![demo](https://github.com/teamMindee/tensorflow-js-demo/releases/download/v0.1-models/demo_app.png)
 
 ## Use the interface
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export default function Sidebar({
   return (
     <Card header="Settings" id={COMPONENT_ID} className={classes.wrapper}>
       <Box display="flex" flexDirection="column ">
-        <Typography>Select a detection model</Typography>
+        <Typography>Select a detection backbone</Typography>
         <Select
           value={detectionModelType}
           onChange={(value) => setDetectionModelType(value)}


### PR DESCRIPTION
This PR updates the readme screenshot and replace the "model" by "backbone" in the sidebar which is more accurate.
Any feedback is welcome!