### PR TITLE
feat: Added Docker deployment option & updated usage instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Run docker container
         run: docker run -d -p 8080:3000 doctr-tfjs:node12-alpine
       - name: Check that the container accepts requests
-        run: sleep 10 & curl localhost:8080
+        run: sleep 10 && curl localhost:8080

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
       - name: Build docker image
         run: DOCKER_BUILDKIT=1 docker build . -t doctr-tfjs:node12-alpine
       - name: Run docker container

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,19 @@
+name: docker
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  docker-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build docker image
+        run: DOCKER_BUILDKIT=1 docker build . -t doctr-tfjs:node12-alpine
+      - name: Run docker container
+        run: docker run -d -p 8080:3000 doctr-tfjs:node12-alpine
+      - name: Check that the container accepts requests
+        run: sleep 10 & curl localhost:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14-slim
+
+WORKDIR /usr/src/app
+
+COPY ./package.json ./
+COPY ./yarn.lock ./
+
+RUN yarn install
+
+COPY ./tsconfig.json ./
+COPY ./.env ./
+COPY ./public ./public
+COPY ./src ./src
+
+CMD [ "yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN set -eux \
 COPY ./package.json ./
 COPY ./yarn.lock ./
 
-RUN yarn install
+RUN yarn install \
+    && yarn cache clean
 
 COPY ./tsconfig.json ./
 COPY ./.env ./
@@ -16,5 +17,6 @@ COPY ./public ./public
 COPY ./src ./src
 
 RUN yarn build \
+    && yarn cache clean \
     && rm -r public src node_modules
 CMD [ "serve", "--no-clipboard", "-s", "build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM node:14-slim
+FROM node:12-alpine
 
 WORKDIR /usr/src/app
+
+RUN set -eux \
+    && npm install -g serve
 
 COPY ./package.json ./
 COPY ./yarn.lock ./
@@ -12,4 +15,6 @@ COPY ./.env ./
 COPY ./public ./public
 COPY ./src ./src
 
-CMD [ "yarn", "start"]
+RUN yarn build \
+    && rm -r public src node_modules
+CMD [ "serve", "-s", "build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY ./src ./src
 
 RUN yarn build \
     && rm -r public src node_modules
-CMD [ "serve", "-s", "build"]
+CMD [ "serve", "--no-clipboard", "-s", "build"]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ The interface is divided into four sections:
 
 ### Prerequisites
 
-In order to install this project, you will need [Yarn](https://classic.yarnpkg.com/lang/en/docs/install), which is a package manager for [Node.js](https://nodejs.org/en/).
+In order to install this project, you will need [Yarn](https://classic.yarnpkg.com/lang/en/docs/install) and [NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), which are package managers for [Node.js](https://nodejs.org/en/).
+
+```shell
+npm install -g serve
+```
 
 ### Installation
 
@@ -50,20 +54,43 @@ This demo was built using [React](https://reactjs.org/), a framework for JavaScr
 git clone https://github.com/mindee/doctr-tfjs-demo.git
 ```
 
-Then install the project using the following command:
+Then install the project's dependencies using the following command:
 
 ```shell
 cd doctr-tfjs-demo
 yarn install
 ```
 
-### Running the app locally
+### Running the app
+
+#### Production mode
+
+Alternatively, if you are looking at a production situation, first build the bundle and serve it:
+```shell
+yarn build
+serve --no-clipboard -s build
+```
+then navigate to the URL with your favorite web browser
+
+#### Development mode
 
 Once all dependencies have been installed, launch the app using:
 ```shell
 yarn start
 ```
-and navigate with your web browser to the URL in the console. 
+and navigate with your web browser to the URL in the console.
+
+### Using Docker container
+
+Lucky for you, if you prefer working with containers, we provide a minimal Docker image. You can build it with:
+```shell
+DOCKER_BUILDKIT=1 docker build . -t doctr-tfjs:node12-alpine
+```
+and then run your image with:
+```shell
+docker run -p 8001:3000 doctr-tfjs:node12-alpine
+```
+Feel free to change the port, but by default, you should be able to access the demo at `http://localhost:8001/`.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ and navigate with your web browser to the URL in the console.
 
 ### Using Docker container
 
-Lucky for you, if you prefer working with containers, we provide a minimal Docker image. You can build it with:
+Lucky for you, if you prefer working with containers, we provide a minimal Docker image. You can build it as follows (it might take a few minutes depending on your setup):
 ```shell
 DOCKER_BUILDKIT=1 docker build . -t doctr-tfjs:node12-alpine
 ```
@@ -90,7 +90,7 @@ and then run your image with:
 ```shell
 docker run -p 8001:3000 doctr-tfjs:node12-alpine
 ```
-Feel free to change the port, but by default, you should be able to access the demo at `http://localhost:8001/`.
+Feel free to change the port, but by default, you should be able to access the demo at `http://localhost:8001/`. *The `-p 8001:3000` lets Docker know that we want to map the internal port of the container (3000) to port 8001 on the outside.*
 
 
 ## License


### PR DESCRIPTION
This PR introduces the following modifications:
- adds a `.dockerignore`
- adds a working Dockerfile for a minimal image (~1Gb)
- adds a CI check to validate the container
- updated README instructions: added guidelines for production deployment (!= development mode), and Docker deployment

Any feedback is welcome!