### PR TITLE
style: Removes unused imports and cleans syntax

### DIFF
--- a/src/components/AnnotationViewer.tsx
+++ b/src/components/AnnotationViewer.tsx
@@ -3,7 +3,7 @@
 // This program is licensed under the Apache License version 2.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-import { Box, makeStyles, Theme } from "@material-ui/core";
+import { makeStyles, Theme } from "@material-ui/core";
 import { Card } from "@mindee/web-elements.ui.card";
 import {
   AnnotationData,

--- a/src/components/HeatMap.tsx
+++ b/src/components/HeatMap.tsx
@@ -3,7 +3,7 @@
 // This program is licensed under the Apache License version 2.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
-import { Box, makeStyles, Theme } from "@material-ui/core";
+import { makeStyles, Theme } from "@material-ui/core";
 import { Card } from "@mindee/web-elements.ui.card";
 import { MutableRefObject } from "react";
 

--- a/src/components/WordsList.tsx
+++ b/src/components/WordsList.tsx
@@ -5,7 +5,6 @@
 
 import React from "react";
 import {
-  Box,
   CircularProgress,
   Grid,
   makeStyles,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -193,24 +193,22 @@ export const getHeatMapFromImage = async ({
   size: number;
 }) =>
   new Promise(async (resolve) => {
-    {
-      if (!heatmapContainer && !detectionModel) {
-        return;
-      }
-
-      heatmapContainer!.width = imageObject.width;
-      heatmapContainer!.height = imageObject.height;
-      let tensor = getImageTensorForDetectionModel(imageObject, size);
-      let prediction: any = await detectionModel?.execute(tensor);
-      // @ts-ignore
-      prediction = squeeze(prediction, 0);
-      if (Array.isArray(prediction)) {
-        prediction = prediction[0];
-      }
-      // @ts-ignore
-      await browser.toPixels(prediction, heatmapContainer);
-      resolve("test");
+    if (!heatmapContainer && !detectionModel) {
+      return;
     }
+
+    heatmapContainer!.width = imageObject.width;
+    heatmapContainer!.height = imageObject.height;
+    let tensor = getImageTensorForDetectionModel(imageObject, size);
+    let prediction: any = await detectionModel?.execute(tensor);
+    // @ts-ignore
+    prediction = squeeze(prediction, 0);
+    if (Array.isArray(prediction)) {
+      prediction = prediction[0];
+    }
+    // @ts-ignore
+    await browser.toPixels(prediction, heatmapContainer);
+    resolve("test");
   });
 function clamp(number: number, size: number) {
   return Math.max(0, Math.min(number, size));


### PR DESCRIPTION
By checking the warning popping up when doing `yarn start`, I spotted a few things to update. This PR introduces the following modifications:
- removes unused imports
- removes a double bracket block (un-indenting and removing the second bracket pair)

Any feedback is welcome!