### PR TITLE
docs: Updated README and renamed interface display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Doctr Tensorflow.js demo
+# docTR Tensorflow.js demo
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) ![Build Status](https://github.com/mindee/doctr-tfjs-demo/workflows/builds/badge.svg)
 
@@ -6,31 +6,24 @@
 
 <br/>
 
-This project is based on [docTR](https://github.com/mindee/doctr).
-It provides a end-to-end OCR built and trained with docTR, deployed with Tensorflow.js.
+This project is based on [docTR](https://github.com/mindee/doctr) and leverages [TensorFlow.js](https://www.tensorflow.org/js) to serve you an end-to-end OCR running directly in your favorite web browser.
 
 <br/><br/>
 
-You can choose between 2 detection models:
-- `db_resnet50`, high-resolution (heavier but stronger)
-- `db_mobilenet_v2`, medium-resolution, (lighter if your computer can't deal with the heavier backbone)
+![demo](https://github.com/teamMindee/tensorflow-js-demo/releases/download/v0.1-models/demo_illustration.png)
 
-The recognition model is the `crnn_vgg16_bn`.
 
-All documentation about models can be found [here](https://mindee.github.io/doctr/models.html).
+For this project, models were trained with docTR using its TensorFlow back-end, then converted to the TJFS SavedModel format thanks to the [`tensorflowjs_converter`](https://www.tensorflow.org/js/tutorials/conversion/import_saved_model). Just like docTR, under the hood, there are two types of modules:
+- **Text detection**: `db_mobilenet_v2` (low resolution) & [`db_resnet50`](https://mindee.github.io/doctr/latest/models.html#doctr.models.detection.db_resnet50) (high resolution) as available architectures, post-processing performed with [OpenCV.js](https://docs.opencv.org/3.4/d5/d10/tutorial_js_root.html).
+- **Text recognition**: [`crnn_vgg16_bn`](https://mindee.github.io/doctr/latest/models.html#doctr.models.recognition.crnn_vgg16_bn) as available architecture
 
-Models were loaded and trained with doctr, then converted to Tensorflow.js savedmodels format
-with the `tensorflowjs_converter`.
+Documentation about all the models can be found over [here](https://mindee.github.io/doctr/models.html).
 
-The segmentation postprocessing is performed with OpenCV.js
 
-This is what it looks like when you launch the app:
+## Using the interface
 
-![demo](https://github.com/teamMindee/tensorflow-js-demo/releases/download/v0.1-models/demo_app.png)
-
-## Use the interface
-
-The interface is divided into four sections:
+The interface is divided into five sections:
+- **Model settings** (side pannel): select the architectures to use for text detection and for text recognition.
 - **Input Image** (top-left pannel): upload your image there by clicking in the area & selecting your file. Uploading a file will automatically run the OCR on it.
 - **Text localization** (top-right pannel): the output of the text localization module.
 - **Detected word boxes** (bottom-left pannel): visualization of the final predictions of the OCR.

--- a/src/components/AnnotationViewer.tsx
+++ b/src/components/AnnotationViewer.tsx
@@ -41,7 +41,7 @@ export default function AnnotationViewer({
   const classes = useStyles();
   return (
     <Card
-      header="Detected word boxes"
+      header="Word predictions"
       id={COMPONENT_ID}
       className={classes.wrapper}
     >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,7 +32,7 @@ export default function Sidebar({
 }: Props): JSX.Element {
   const classes = useStyles();
   return (
-    <Card header="Settings" id={COMPONENT_ID} className={classes.wrapper}>
+    <Card header="Model selection" id={COMPONENT_ID} className={classes.wrapper}>
       <Box display="flex" flexDirection="column ">
         <Typography>Text detection architecture (backbone)</Typography>
         <Select

--- a/src/components/WordsList.tsx
+++ b/src/components/WordsList.tsx
@@ -55,7 +55,7 @@ export default function WordsList({
   const classes = useStyles();
   return (
     <Card
-      header={`Words ${words.length ? `(${words.length})` : ""}`}
+      header={`Words values ${words.length ? `(${words.length})` : ""}`}
       id={COMPONENT_ID}
       className={classes.wrapper}
     >


### PR DESCRIPTION
This PR introduces the following modifications:
- updates the README by adding multiple hyperrefs, and clarifying how models are served
- updates some component display names

Here is how it renders:
![demo](https://github.com/teamMindee/tensorflow-js-demo/releases/download/v0.1-models/demo_illustration.png)

Any feedback is welcome!